### PR TITLE
Update to /v2 api endpoint

### DIFF
--- a/lib/OBook.js
+++ b/lib/OBook.js
@@ -27,7 +27,7 @@ class OBook {
         const info = await client.fetch(this.infoUrl, this.cookie)
         const meta = await client.fetch(this.bookUrl, this.cookie)
 
-        // this.validateFormat(meta.format) To Do: ****** REWRITE VALIDATION ***
+        this.validateFormat(meta.content_format)
         const title = meta.title
         const author = this.joinNames(info.authors)
         const publisher = this.joinNames(info.publishers)
@@ -35,7 +35,7 @@ class OBook {
         const bookFolder = this.createBookFolder(filename)
         const chapter = await client.fetch(meta.chapters, this.cookie)
         const cover = await this.fetchMaybeCoverImageUrl(chapter.results)
-        
+
         chapter.results.shift()
         const chapters = chapter.results
 

--- a/lib/OBook.js
+++ b/lib/OBook.js
@@ -1,4 +1,4 @@
-const { existsSync, mkdirSync, rmdirSync } = require('fs')
+const { existsSync, mkdirSync, rmSync } = require('fs')
 const cheerio = require('cheerio')
 const Epub = require("epub-gen")
 const url = require('url')
@@ -58,7 +58,7 @@ class OBook {
             .then(
                 () => {
                     if (existsSync(`${bookFolder}images`)) {
-                        rmdirSync(`${bookFolder}images`, { recursive: true })
+                        rmSync(`${bookFolder}images`, { recursive: true })
                         log(`done 📚✨`)
                     }
                 },

--- a/lib/OBook.js
+++ b/lib/OBook.js
@@ -114,6 +114,14 @@ class OBook {
         const coverUrl = bookImageUtils.findCoverElement(chapters)
         if (coverUrl !== undefined) {
             const fullPath = String(coverUrl.related_assets.images)
+
+            if (fullPath.length == 0)   {
+                const altPath = String(coverUrl.related_assets.html_files).split('/').pop().replace(/\.[^\/.]+$/, '')
+                const newPath = bookImageUtils.buildCoverFilePath(this.bookid, altPath)
+
+                return isUrl(newPath) ? newPath : undefined
+            }
+
             return isUrl(fullPath) ? fullPath : undefined
         }
     }

--- a/lib/OBook.js
+++ b/lib/OBook.js
@@ -9,37 +9,40 @@ const { log, isUrl} = require('./utils')
 const bookImageUtils = require('./book-image-utils')
 const client = require('./client')
 
-const OREILLY_API_BOOK_URL = 'https://learning.oreilly.com/api/v1/book'
+const OREILLY_API_BOOK_INFO_URL = 'https://learning.oreilly.com/api/v1/book'
+const OREILLY_API_BOOK_URL = 'https://learning.oreilly.com/api/v2/epubs/urn:orm:book'
 const DEST_PATH = path.dirname(require.main.filename) + '/books/'
 
 class OBook {
     constructor(cookie, bookid) {
         this.cookie = cookie
         this.bookid = bookid
-        this.bookUrl = `${OREILLY_API_BOOK_URL}/${bookid}`
+        this.infoUrl = `${OREILLY_API_BOOK_INFO_URL}/${bookid}`
+        this.bookUrl = `${OREILLY_API_BOOK_URL}:${bookid}`    
     }
 
     async create() {
         if (!existsSync(DEST_PATH)) mkdirSync(DEST_PATH, { recursive: true })
 
+        const info = await client.fetch(this.infoUrl, this.cookie)
         const meta = await client.fetch(this.bookUrl, this.cookie)
-        this.validateFormat(meta.format)
 
+        // this.validateFormat(meta.format) To Do: ****** REWRITE VALIDATION ***
         const title = meta.title
-        const author = this.joinNames(meta.authors)
-        const publisher = this.joinNames(meta.publishers)
-        const cover = await this.fetchMaybeCoverImageUrl(meta.chapters)
+        const author = this.joinNames(info.authors)
+        const publisher = this.joinNames(info.publishers)
         const filename = title.toLowerCase().replace(/\s+|[:?<>"]/g, '-')
         const bookFolder = this.createBookFolder(filename)
-
-        meta.chapters.shift()
-        const chapterUrls = meta.chapters
+        const chapter = await client.fetch(meta.chapters, this.cookie)
+        const cover = await this.fetchMaybeCoverImageUrl(chapter.results)
+        
+        chapter.results.shift()
+        const chapters = chapter.results
 
         log(`downloading: ${title}`)
-        log(`${chapterUrls.length} chapters to download, please wait...`)
+        log(`${chapters.length} chapters to download, please wait...`)
 
-        const chapters = await client.parallelFetch(chapterUrls, this.cookie)
-        const chapterContentUrls = chapters.map(ch => ch.content)
+        const chapterContentUrls = chapters.map(ch => ch.content_url)
         const contents = await client.parallelFetch(chapterContentUrls, this.cookie)
         await this.downloadImages(chapters, bookFolder)
 
@@ -109,20 +112,17 @@ class OBook {
 
     async fetchMaybeCoverImageUrl(chapters) {
         const coverUrl = bookImageUtils.findCoverElement(chapters)
-
         if (coverUrl !== undefined) {
-            const coverPage = await client.fetch(coverUrl, this.cookie)
-            const coverImagePath = bookImageUtils.findCoverElement(coverPage.images)
-
-            const fullPath = bookImageUtils.buildCoverFilePath(this.bookid, coverImagePath)
+            const fullPath = String(coverUrl.related_assets.images)
             return isUrl(fullPath) ? fullPath : undefined
         }
     }
 
     async downloadImages(chapters, bookFolderPath) {
         for (let chapter of chapters) {
-            const imagePaths = chapter.images
-            const assetBasetUrl = chapter.asset_base_url
+            const imagePaths = chapter.related_assets.images
+            const assetBasetUrl = chapter.epub_archive
+
             if (imagePaths.length || isUrl(assetBasetUrl)) {
                 await this.parallelDownloadImages(
                     imagePaths,
@@ -143,8 +143,7 @@ class OBook {
                     if (!existsSync(localImagesPath)) {
                         mkdirSync(localImagesPath, { recursive: true })
                     }
-                    const oReillyImageUrl = assetBaseUrl + imagePath;
-                    return client.downloadIMG({ url: oReillyImageUrl, dest })
+                    return client.downloadIMG({ url: imagePath, dest })
                 }
             })
             return async.parallel(requests)

--- a/lib/book-image-utils.js
+++ b/lib/book-image-utils.js
@@ -13,7 +13,7 @@ function findCoverElement(listOfStrings) {
 function buildCoverFilePath(bookId,
                             coverPath) {
     if (bookId !== undefined && coverPath !== undefined) {
-        return `https://learning.oreilly.com/api/v2/epubs/urn:orm:book:${bookId}/files/${coverPath}`
+        return `https://learning.oreilly.com/api/v2/epubs/urn:orm:book:${bookId}/files/images/${coverPath}.jpg`
     }
 }
 

--- a/lib/book-image-utils.js
+++ b/lib/book-image-utils.js
@@ -1,8 +1,15 @@
 function findCoverElement(listOfStrings) {
     const coverImageKeywords = ['cover', 'titlepage']
-    return listOfStrings.find(list => coverImageKeywords.some(keyword => list.includes(keyword)))
+    const coverPages = listOfStrings.filter(list => coverImageKeywords.some(keyword => list.reference_id.toLowerCase().includes(keyword)));
+    // Return first cover page identified
+    if (coverPages.length > 0) {
+      return coverPages[0];
+    }
+    return null;
 }
 
+// This will need to change, as some books use the graphics endpoint (/api/v2/epubs/urn:orm:book:${bookId}/files/graphics/${coverPath})
+// Not currently in use in this iteration
 function buildCoverFilePath(bookId,
                             coverPath) {
     if (bookId !== undefined && coverPath !== undefined) {


### PR DESCRIPTION
This fix should resolve the issue regarding the covers/images that is present on the main branch of this project. I updated the functionality of it to support the /v2 api endpoints that is used by default in O'Reilly, and resolved the depreciation warning from node.

Do note that there's still no proper error handling for the 500 error on images, so if those do come up at a later time, that would still need to be resolved, meaning that Issue #21 should still be open following this merge.